### PR TITLE
Fatal error while displaying a new quiz

### DIFF
--- a/attempt.php
+++ b/attempt.php
@@ -175,7 +175,7 @@ for ($i = 0; $i < $numpages; $i++) {
     $form .= html_writer::start_div('quiz-loading-hide',
             array('id' => 'quizaccess_offlinemode-attempt_page-' . $i));
     foreach ($attemptobj->get_slots($i) as $slot) {
-        $form .= $attemptobj->render_question($slot, false,
+        $form .= $attemptobj->render_question($slot, false, $output
                 $attemptobj->attempt_url($slot, $page));
     }
     $form .= html_writer::end_div('');


### PR DESCRIPTION
After creating a new Quiz with a few basic core MC questions and trying to start a new attempt, I am getting the following fatal error.
I do not have this issue on old quizzes just on new ones.

Debug info: Argument 3 passed to quiz_attempt::render_question() must be an instance of mod_quiz_renderer, instance of moodle_url given, called in [dirroot]/mod/quiz/accessrule/offlinemode/attempt.php on line 179 and defined
Error code: codingerror
Stack trace:
line 393 of /lib/setuplib.php: coding_exception thrown
line 1434 of /mod/quiz/attemptlib.php: call to default_error_handler()
line 179 of /mod/quiz/accessrule/offlinemode/attempt.php: call to quiz_attempt->render_question()

Adding what seems like a missing "$output" quiz renderer as 3rd param to $attemptobj->render_question() line 178 seems to fix this issue.
Please verify :-)